### PR TITLE
feat: 主题发布支持图片上传

### DIFF
--- a/extension/manifest-firefox.json
+++ b/extension/manifest-firefox.json
@@ -45,13 +45,18 @@
     },
     {
       "matches": ["https://v2ex.com/*", "https://www.v2ex.com/*"],
-      "exclude_matches": ["*://*/t/*", "*://*/notes/*", "*://*/settings"],
+      "exclude_matches": ["*://*/t/*", "*://*/notes/*", "*://*/settings", "*://*/write"],
       "js": ["scripts/v2ex-home.min.js"],
       "all_frames": true
     },
     {
       "matches": ["https://v2ex.com/t/*", "https://www.v2ex.com/t/*"],
       "js": ["scripts/v2ex-topic.min.js"],
+      "all_frames": true
+    },
+    {
+      "matches": ["https://v2ex.com/write", "https://www.v2ex.com/write"],
+      "js": ["scripts/v2ex-write.min.js"],
       "all_frames": true
     },
     {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -33,13 +33,18 @@
     },
     {
       "matches": ["https://v2ex.com/*", "https://www.v2ex.com/*"],
-      "exclude_matches": ["*://*/t/*", "*://*/notes/*", "*://*/settings"],
+      "exclude_matches": ["*://*/t/*", "*://*/notes/*", "*://*/settings", "*://*/write"],
       "js": ["scripts/v2ex-home.min.js"],
       "all_frames": true
     },
     {
       "matches": ["https://v2ex.com/t/*", "https://www.v2ex.com/t/*"],
       "js": ["scripts/v2ex-topic.min.js"],
+      "all_frames": true
+    },
+    {
+      "matches": ["https://v2ex.com/write", "https://www.v2ex.com/write"],
+      "js": ["scripts/v2ex-write.min.js"],
       "all_frames": true
     },
     {

--- a/src/components/image-upload.ts
+++ b/src/components/image-upload.ts
@@ -1,0 +1,99 @@
+import { uploadImage } from '../services'
+
+interface ImageUploadProps {
+  $el: JQuery
+  insertText: (text: string) => void // 插入文本的实现
+  replaceText: (find: string, replace: string) => void // 替换文本的实现，当 replace 为非空字符串时，表示图片上传成功，参数值为图片链接。
+}
+
+const uploadTip = '选择、粘贴、拖放上传图片。'
+
+export function bindImageUpload(props: ImageUploadProps) {
+  const { $el, insertText, replaceText } = props
+  const $uploadBar = $(`<div class="v2p-reply-upload-bar">${uploadTip}</div>`)
+
+  const handleUploadImage = (file: File) => {
+    const placeholder = '[上传图片中...]'
+    insertText(` ${placeholder} `)
+    $uploadBar.addClass('v2p-reply-upload-bar-disabled').text('正在上传图片...')
+
+    uploadImage(file)
+      .then((imgLink) => {
+        replaceText(placeholder, imgLink)
+      })
+      .catch(() => {
+        replaceText(placeholder, '')
+
+        window.alert('❌ 上传图片失败，请打开控制台查看原因')
+      })
+      .finally(() => {
+        $uploadBar.removeClass('v2p-reply-upload-bar-disabled').text(uploadTip)
+      })
+  }
+
+  const handleClickUploadImage = () => {
+    const imgInput = document.createElement('input')
+
+    imgInput.style.display = 'none'
+    imgInput.type = 'file'
+    imgInput.accept = 'image/*'
+
+    imgInput.addEventListener('change', () => {
+      const selectedFile = imgInput.files?.[0]
+
+      if (selectedFile) {
+        handleUploadImage(selectedFile)
+      }
+    })
+
+    imgInput.click()
+  }
+
+  // 粘贴图片并上传的功能。
+  document.addEventListener('paste', (ev) => {
+    if (!(ev instanceof ClipboardEvent) || !$el.get(0)?.matches(':focus')) {
+      return
+    }
+
+    const items = ev.clipboardData?.items
+
+    if (!items) {
+      return
+    }
+
+    // 查找图像类型的数据项
+    const imageItem = Array.from(items).find((item) => item.type.includes('image'))
+
+    if (imageItem) {
+      const file = imageItem.getAsFile()
+
+      if (file) {
+        handleUploadImage(file)
+      }
+    }
+  })
+
+  $el.get(0)?.addEventListener('drop', (ev) => {
+    ev.preventDefault()
+
+    if (!(ev instanceof DragEvent)) {
+      return
+    }
+
+    const file = ev.dataTransfer?.files[0]
+
+    if (file) {
+      handleUploadImage(file)
+    }
+  })
+
+  $('.flex-one-row:last-of-type > .gray').text('')
+
+  $uploadBar.on('click', () => {
+    if (!$uploadBar.hasClass('v2p-reply-upload-bar-disabled')) {
+      handleClickUploadImage()
+    }
+  })
+
+  $el.append($uploadBar)
+}

--- a/src/contents/topic/index.ts
+++ b/src/contents/topic/index.ts
@@ -1,8 +1,8 @@
-import { MessageFrom, StorageKey } from '../../constants'
+import { StorageKey } from '../../constants'
 import { iconReply, iconScrollTop } from '../../icons'
-import type { MessageData } from '../../types'
 import { getRunEnv, getStorage, injectScript } from '../../utils'
 import { $commentTableRows, $replyBox, $replyTextArea } from '../globals'
+import { hostCall } from '../helpers'
 import { handlingComments } from './comment'
 import { handlingContent } from './content'
 import { handlingPaging } from './paging'
@@ -14,17 +14,8 @@ void (async () => {
   const runEnv = getRunEnv()
 
   if (runEnv === 'chrome' || runEnv === 'web-ext') {
-    injectScript(chrome.runtime.getURL('scripts/web_accessible_resources.min.js'))
-
-    window.addEventListener('message', (ev: MessageEvent<MessageData>) => {
-      if (ev.data.from === MessageFrom.Web) {
-        const payload = ev.data.payload
-
-        if (payload?.once) {
-          window.once = payload.once // 从 Web 页获取到 once 变量（与 CSRF 有关），请求接口时会用到。
-        }
-      }
-    })
+    await injectScript(chrome.runtime.getURL('scripts/web_accessible_resources.min.js'))
+    window.once = await hostCall('window.once')
   }
 
   if (options.openInNewTab) {

--- a/src/contents/write/index.ts
+++ b/src/contents/write/index.ts
@@ -1,0 +1,12 @@
+import { getRunEnv, injectScript } from '../../utils'
+import { handlerWrite } from './write'
+
+void (async () => {
+  const runEnv = getRunEnv()
+
+  if (runEnv === 'chrome' || runEnv === 'web-ext') {
+    await injectScript(chrome.runtime.getURL('scripts/web_accessible_resources.min.js'))
+  }
+
+  handlerWrite()
+})()

--- a/src/contents/write/write.ts
+++ b/src/contents/write/write.ts
@@ -18,7 +18,6 @@ export function handlerWrite() {
 
       void hostCall(`
       editor.setValue(editor.getValue().replace("${find}", "${replace}"));
-      editor.focus();
       const doc = editor.getDoc(); 
       const lastLine = doc.lastLine(); 
       const lastChar = doc.getLine(lastLine).length; 

--- a/src/contents/write/write.ts
+++ b/src/contents/write/write.ts
@@ -1,0 +1,29 @@
+import { bindImageUpload } from '../../components/image-upload'
+import { hostCall } from '../helpers'
+
+export function handlerWrite() {
+  bindImageUpload({
+    $el: $('#workspace'),
+    insertText: (text: string) => {
+      void hostCall(`editor.getDoc().replaceRange("${text}", editor.getCursor())`)
+    },
+    replaceText: (find: string, replace: string) => {
+      if (replace) {
+        // 特殊处理markdown模式下的图片插入格式
+        const mode = $('input[name=syntax]:checked').val()
+        if (mode === 'markdown') {
+          replace = `![](${replace})`
+        }
+      }
+
+      void hostCall(`
+      editor.setValue(editor.getValue().replace("${find}", "${replace}"));
+      editor.focus();
+      const doc = editor.getDoc(); 
+      const lastLine = doc.lastLine(); 
+      const lastChar = doc.getLine(lastLine).length; 
+      doc.setCursor({ line: doc.lastLine(), ch: lastChar });
+      `)
+    },
+  })
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,6 +226,10 @@ export interface V2EX_Response {
 export interface MessageData {
   from: MessageFrom
   payload?: {
-    once?: string
+    call?: {
+      id: string
+      exp: string
+      ret?: any
+    }
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -195,11 +195,16 @@ export function escapeHTML(htmlString: string): string {
 /**
  * 向 HTML body 下动态插入脚本。
  */
-export function injectScript(scriptSrc: string) {
-  const script = document.createElement('script')
-  script.setAttribute('type', 'text/javascript')
-  script.setAttribute('src', scriptSrc)
-  document.body.appendChild(script)
+export function injectScript(scriptSrc: string): Promise<void> {
+  return new Promise((resolve) => {
+    const script = document.createElement('script')
+    script.setAttribute('type', 'text/javascript')
+    script.setAttribute('src', scriptSrc)
+    script.onload = () => {
+      resolve()
+    }
+    document.body.appendChild(script)
+  })
 }
 
 /**

--- a/src/web_accessible_resources.ts
+++ b/src/web_accessible_resources.ts
@@ -3,7 +3,6 @@ import type { MessageData } from './types'
 
 declare global {
   interface Window {
-    thankReply: () => void
     once: string
   }
 }
@@ -12,12 +11,13 @@ window.addEventListener('message', (ev: MessageEvent<MessageData>) => {
   if (ev.data.from === MessageFrom.Content) {
     const payload = ev.data.payload
 
-    if (payload?.once) {
-      window.once = payload.once // 从 Content 页获取到 once 后更新回 Web 页的 once。
+    if (payload?.call?.exp) {
+      const ret = eval(payload.call.exp)
+      window.postMessage({
+        from: MessageFrom.Web,
+
+        payload: { call: { id: payload.call.id, ret } },
+      })
     }
   }
 })
-
-const messageData: MessageData = { from: MessageFrom.Web, payload: { once: window.once } }
-
-window.postMessage(messageData)

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     'common.min': 'src/contents/common.ts',
     'v2ex-home.min': 'src/contents/home/index.ts',
     'v2ex-topic.min': 'src/contents/topic/index.ts',
+    'v2ex-write.min': 'src/contents/write/index.ts',
     'decode-base64.min': 'src/contents/decode-base64.ts',
     'reading-list.min': 'src/contents/reading-list.ts',
 


### PR DESCRIPTION
感谢大佬的扩展，我把回复那边的图片上传封装成了一个公共组件，然后在回复和主题发布两边复用了，效果如下图：

![image](https://github.com/coolpace/V2EX_Polish/assets/13160176/742f76af-0551-4f43-bcdf-49021d1ae96a)

有个比较大的改动就是宿主环境和扩展环境通信的交互，我重新设计了下以支持更通用的宿主调用方式，具体你可以review下代码，看看能不能接受，因为主题发布那边需要操作宿主环境的`editor`变量，v2那边主题发布用的`CodeMirror`编辑器，不这样改的话实现起来会很麻烦，而且以后如果有类似需求也方便开发。
