### PR TITLE
插件调试时默认打开v2ex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 
 # web-ext 产生的浏览器配置
 /*-profile
+/.idea

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "dev": "run-p watch run:chrome",
     "dev:firefox": "run-p watch run:firefox",
-    "run:chrome": "web-ext run -t chromium --source-dir ./extension --chromium-profile ./chrome-profile --profile-create-if-missing",
-    "run:firefox": "web-ext run --source-dir ./extension",
+    "run:chrome": "web-ext run -t chromium --source-dir ./extension --chromium-profile ./chrome-profile --profile-create-if-missing --start-url https://www.v2ex.com/",
+    "run:firefox": "web-ext run --source-dir ./extension --start-url https://www.v2ex.com/",
     "build": "bun build:all && bun scripts/build.ts && bun pack:chrome && bun pack:firefox",
     "build:all": "run-p build:style build:ext build:userscript",
     "build:userscript": "run-s output:css output:userscript",


### PR DESCRIPTION
这样做可以方便开发者调试插件~