### PR TITLE
fix: 优化深色模式下浏览器窗口滚动条的颜色

### DIFF
--- a/src/styles/v2ex-theme-dark.scss
+++ b/src/styles/v2ex-theme-dark.scss
@@ -61,6 +61,9 @@
     --v2p-toast-shadow: none;
     // ---- 阴影 ----
 
+    // 滚动条
+    --v2p-scrollbar-background-color: #22303f;
+
     // V2EX 原有的 CSS 变量：
     --link-color: var(--v2p-color-foreground);
     --box-background-alt-color: var(--v2p-color-main-100);

--- a/src/styles/v2ex-theme-default.scss
+++ b/src/styles/v2ex-theme-default.scss
@@ -715,6 +715,19 @@ body {
   textarea {
     color: var(--v2p-color-foreground);
   }
+
+  /* ------ 浏览器窗口滚动条 ------ */
+  // Webkit
+  &::-webkit-scrollbar-track {
+    background-color: var(--v2p-scrollbar-background-color);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background-color: var(--v2p-color-foreground);
+  }
+
+  // Firefox
+  scrollbar-color: var(--v2p-color-foreground) var(--v2p-scrollbar-background-color);
 }
 
 /* ====== 帖子标签 ====== */

--- a/src/styles/v2ex-theme-var.scss
+++ b/src/styles/v2ex-theme-var.scss
@@ -99,6 +99,9 @@
       0 9px 28px 8px rgb(0 0 0 / 5%);
     // ---- 阴影 ----
 
+    // 滚动条
+    --v2p-scrollbar-background-color: #fcfcfc;
+
     // V2EX 原有的 CSS 变量：
     --color-fade: var(--v2p-color-font-secondary);
     --color-gray: var(--v2p-color-font-secondary);


### PR DESCRIPTION
#106 

滚动条轨道背景颜色没有像滑块一样使用已有的var变量，是考虑到希望滚动条和主体内容有区分度。
