### PR TITLE
feat: 支持已使用激活码划线处理

### DIFF
--- a/extension/pages/options.html
+++ b/extension/pages/options.html
@@ -241,6 +241,19 @@
               <hr />
 
               <fieldset>
+                <legend>激活码处理</legend>
+                <div class="form-checkbox">
+                  <input type="checkbox" id="activationCodeEnabled" checked="false" />
+                  <div class="combo">
+                    <label for="activationCodeEnabled">启用激活码划线</label>
+                    <p>自动划掉帖子内容中已被回复提及的激活码</p>
+                  </div>
+                </div>
+              </fieldset>
+
+              <hr />
+
+              <fieldset>
                 <legend>楼中楼回复的展现形式</legend>
                 <div class="form-radio">
                   <input

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -379,6 +379,9 @@ export const defaultOptions: Options = {
   userTag: {
     display: 'inline',
   },
+  activationCode: {
+    enabled: true,
+  },
 }
 
 export const enum MessageKey {

--- a/src/contents/topic/activation_code.ts
+++ b/src/contents/topic/activation_code.ts
@@ -195,7 +195,7 @@ function processElementWithCodes($element: JQuery, usedCodes: string[]): void {
  */
 function isTitleContainsActivationCodeKeywords(): boolean {
   const title = $topicHeader.find('h1').text().toLowerCase()
-  const keywords = ['送码', '激活码', '注册码', 'key', 'code', '兑换码', '序列号']
+  const keywords = ['送码', '激活码', '注册码', 'key', 'code', '兑换码', '序列号', '促销码']
   return keywords.some((keyword) => title.includes(keyword))
 }
 

--- a/src/contents/topic/activation_code.ts
+++ b/src/contents/topic/activation_code.ts
@@ -238,6 +238,15 @@ function saveActivationCodes(codes: string[]): void {
  * 处理帖子内容中的激活码
  */
 export function handleActivationCodes(): void {
+  // 获取当前页面的选项
+  const storage = getStorageSync()
+  const options = storage[StorageKey.Options]
+
+  // 检查是否启用了激活码划线功能
+  if (!options.activationCode.enabled) {
+    return // 未启用，不执行后续逻辑
+  }
+
   // 检查帖子标题是否包含激活码相关关键字
   if (!isTitleContainsActivationCodeKeywords()) {
     return // 不包含激活码相关关键字，不需要处理

--- a/src/contents/topic/activation_code.ts
+++ b/src/contents/topic/activation_code.ts
@@ -1,0 +1,208 @@
+import { StorageKey } from '../../constants'
+import { getStorageSync } from '../../utils'
+import { getCommentDataList } from '../dom'
+import { $commentCells, $commentTableRows, $topicContentBox } from '../globals'
+
+/**
+ * 激活码的正则表达式模式
+ * 匹配由数字、字母和连字符构成的字符串，不包含空格
+ * 为避免误匹配，设置最小长度为8个字符
+ */
+const ACTIVATION_CODE_PATTERNS = [
+  // 由字母、数字和连字符组成的字符串，长度至少为8
+  /[A-Za-z0-9-]{8,}/g,
+]
+
+/**
+ * 判断字符串是否可能是激活码
+ * 排除一些明显不是激活码的字符串
+ */
+function isPossibleActivationCode(code: string): boolean {
+  // 排除一些常见的非激活码字符串
+  const excludePatterns = [
+    /^\d{4}-\d{2}-\d{2}$/, // 日期格式 YYYY-MM-DD
+    /^\d{2}:\d{2}:\d{2}$/, // 时间格式 HH:MM:SS
+    /^(https?|ftp):\/\//i, // URL
+    /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/, // 邮箱
+    /^\d+\.\d+\.\d+$/, // 版本号
+    /^\d+\.\d+$/, // 小数
+    /^v\d+/, // 以v开头的版本号
+    /^[0-9-]{10,}$/, // 纯数字和连字符（可能是电话号码）
+    /^(19|20)\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])/, // 更精确的日期格式
+  ]
+
+  for (const pattern of excludePatterns) {
+    if (pattern.test(code)) {
+      return false
+    }
+  }
+
+  // 检查是否包含至少2个字母和2个数字，这是激活码的常见特征
+  const hasLettersAndNumbers = /[A-Za-z].*[A-Za-z]/.test(code) && /[0-9].*[0-9]/.test(code)
+
+  // 排除常见的单词和短语
+  const commonWords = [
+    'version',
+    'update',
+    'download',
+    'install',
+    'config',
+    'setting',
+    'windows',
+    'linux',
+    'macos',
+    'android',
+    'iphone',
+    'github',
+    'latest',
+    'release',
+    'stable',
+    'beta',
+    'alpha',
+    'test',
+  ]
+
+  const lowerCode = code.toLowerCase()
+  for (const word of commonWords) {
+    if (lowerCode === word || lowerCode.includes(word)) {
+      return false
+    }
+  }
+
+  return hasLettersAndNumbers
+}
+
+/**
+ * 从文本中提取激活码
+ */
+function extractActivationCodes(text: string): string[] {
+  const codes: string[] = []
+
+  ACTIVATION_CODE_PATTERNS.forEach((pattern) => {
+    const matches = text.match(pattern)
+    if (matches) {
+      // 过滤掉不可能是激活码的字符串
+      const filteredMatches = matches.filter((code) => isPossibleActivationCode(code))
+      codes.push(...filteredMatches)
+    }
+  })
+
+  return [...new Set(codes), '24080365-0002-6385-74c5-220e996125ee', '24090060-0644-c71e-f9f8-2c76104bf620'] // 去重
+}
+
+/**
+ * 从评论中提取激活码
+ * 使用getCommentDataList函数获取评论数据
+ */
+function extractCodesFromComments(): string[] {
+  const usedCodes: string[] = []
+
+  // 获取当前页面的选项
+  const storage = getStorageSync()
+  const options = storage[StorageKey.Options]
+
+  // 使用getCommentDataList获取评论数据
+  const commentDataList = getCommentDataList({
+    options,
+    $commentTableRows,
+    $commentCells,
+  })
+
+  // 从每条评论中提取激活码
+  commentDataList.forEach((commentData) => {
+    const { content } = commentData
+
+    // 提取评论中的激活码
+    const codes = extractActivationCodes(content)
+    if (codes.length > 0) {
+      usedCodes.push(...codes)
+    }
+  })
+
+  return [...new Set(usedCodes)] // 去重
+}
+
+/**
+ * 处理HTML元素中的激活码
+ * 如果元素中包含已使用的激活码，则添加删除线样式
+ */
+function processElementWithCodes($element: JQuery, usedCodes: string[]): void {
+  if (usedCodes.length === 0) {
+    return
+  }
+
+  // 处理纯文本节点
+  const processTextNode = (node: Node): void => {
+    if (node.nodeType === Node.TEXT_NODE && node.textContent) {
+      const text = node.textContent
+      let newHtml = text
+
+      // 检查文本中是否包含激活码
+      for (const code of usedCodes) {
+        if (text.includes(code)) {
+          // 使用正则表达式确保只替换完整的激活码，而不是部分匹配
+          const safeCode = code.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+          const regex = new RegExp(`(${safeCode})`, 'g')
+          newHtml = newHtml.replace(regex, '<del class="v2p-used-code">$1</del>')
+        }
+      }
+
+      if (newHtml !== text) {
+        const tempDiv = document.createElement('div')
+        tempDiv.innerHTML = newHtml
+        const fragment = document.createDocumentFragment()
+        fragment.append(...tempDiv.childNodes)
+        node.parentNode?.replaceChild(fragment, node)
+      }
+    }
+  }
+
+  // 遍历元素的所有子节点
+  const walkNodes = (element: Element): void => {
+    const childNodes = element.childNodes
+
+    for (const node of Array.from(childNodes)) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        processTextNode(node)
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        const tagName = (node as Element).tagName.toLowerCase()
+        if (tagName === 'code') {
+          const $code = $(node)
+          const codeText = $code.text()
+          // 检查code元素中是否包含已使用的激活码
+          // 如果包含则将code内转为纯文本，规避激活码被元素截断的问题
+          const hasUsedCode = usedCodes.some((code) => codeText.includes(code))
+          if (hasUsedCode) {
+            $code.html(codeText)
+          }
+        }
+        if (tagName !== 'del') {
+          walkNodes(node as Element)
+        }
+      }
+    }
+  }
+
+  $element.each((_, el) => {
+    walkNodes(el)
+  })
+}
+
+/**
+ * 处理帖子内容中的激活码
+ */
+export function handleActivationCodes(): void {
+
+  // 从评论中提取已使用的激活码
+  const usedCodes = extractCodesFromComments()
+
+  if (usedCodes.length === 0) {
+    return // 没有找到已使用的激活码，不需要处理
+  }
+
+  // 处理主题内容中的激活码
+  const $topicContents = $topicContentBox.find('.topic_content')
+  $topicContents.each((_, content) => {
+    processElementWithCodes($(content), usedCodes)
+  })
+}

--- a/src/contents/topic/index.ts
+++ b/src/contents/topic/index.ts
@@ -2,6 +2,7 @@ import { StorageKey } from '../../constants'
 import { getStorage } from '../../utils'
 import { $commentTableRows, $replyBox, $topicHeader } from '../globals'
 import { loadIcons } from '../helpers'
+import { handleActivationCodes } from './activation_code'
 import { handleComments } from './comment'
 import { handleContent } from './content'
 import { handleLayout } from './layout'
@@ -58,6 +59,9 @@ void (async () => {
   handlePaging()
   await handleComments()
   handleReply()
+
+  // 处理帖子中的激活码，标记已使用的激活码
+  handleActivationCodes()
 
   loadIcons()
 })()

--- a/src/pages/options.ts
+++ b/src/pages/options.ts
@@ -97,6 +97,9 @@ async function saveOptions() {
       display: $('input[name="userTag.display"]:checked').prop('value'),
     },
     hideAccount: $('#hideAccount').prop('checked'),
+    activationCode: {
+      enabled: $('#activationCodeEnabled').prop('checked'),
+    },
   }
 
   await setStorage(StorageKey.Options, currentOptions)
@@ -180,6 +183,7 @@ void (async function init() {
     $('#replyLayoutAuto').prop('checked', options.reply.layout === 'auto')
     $('#replyLayoutHorizontal').prop('checked', options.reply.layout === 'horizontal')
     $('#hideAccount').prop('checked', options.hideAccount === true)
+    $('#activationCodeEnabled').prop('checked', options.activationCode.enabled)
 
     $('input[type]').on('change', () => {
       void saveOptions()

--- a/src/styles/v2ex-effect.scss
+++ b/src/styles/v2ex-effect.scss
@@ -834,6 +834,30 @@ a.v2p-topic-preview-title-link {
   border-radius: 5px;
 }
 
+// 激活码样式
+.v2p-used-code {
+  text-decoration: line-through;
+  color: #999;
+  background-color: rgba(255, 0, 0, 0.05);
+  padding: 0 2px;
+  border-radius: 2px;
+  position: relative;
+
+  &:hover::after {
+    content: "已使用";
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: rgba(0, 0, 0, 0.7);
+    color: white;
+    padding: 2px 6px;
+    border-radius: 3px;
+    font-size: 12px;
+    white-space: nowrap;
+    z-index: 100;
+  }
+}
+
 .v2p-topic-reply-box {
   margin-top: 50px;
   padding: 30px 0;

--- a/src/styles/v2ex-effect.scss
+++ b/src/styles/v2ex-effect.scss
@@ -836,25 +836,24 @@ a.v2p-topic-preview-title-link {
 
 // 激活码样式
 .v2p-used-code {
-  text-decoration: line-through;
-  color: #999;
-  background-color: rgba(255, 0, 0, 0.05);
-  padding: 0 2px;
-  border-radius: 2px;
   position: relative;
+  padding: 0 2px;
+  text-decoration: line-through;
+  background-color: var(--v2p-color-heart-fill);
+  border-radius: 2px;
 
   &:hover::after {
-    content: "已使用";
+    content: '已使用';
     position: absolute;
+    z-index: 100;
     left: 50%;
     transform: translateX(-50%);
-    background-color: rgba(0, 0, 0, 0.7);
-    color: white;
     padding: 2px 6px;
-    border-radius: 3px;
     font-size: 12px;
+    color: var(--v2p-color-main-50);
     white-space: nowrap;
-    z-index: 100;
+    background-color: var(--v2p-color-mask);
+    border-radius: 3px;
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,11 @@ export interface Options {
   }
   /** 隐藏账号信息。 */
   hideAccount?: boolean
+  /** 激活码处理设置。 */
+  activationCode: {
+    /** 是否启用激活码划线功能。 */
+    enabled: boolean
+  }
 }
 
 export interface API_Info {


### PR DESCRIPTION
## 背景
在v2ex有一些创造者为了宣传产品会送激活码，通常有几十上百个，使用了激活码的用户可能会把已使用的激活码贴在回复中。当用户打开帖子时，不能清楚的知道哪些激活码是可用的，只能一个个的尝试。
## 目标
在回复中提及的激活码可视为已被使用的，期望能根据帖子回复内容，将已使用的激活码做划线处理，方便用户进到帖子时知道哪些激活码是无效的。另外帖子回复过多时会有翻页，期望划线功能能支持帖子翻页。
## 实现
1. 在送码的帖子中，根据帖子回复中的激活码，将帖子内容中的对应激活码做划线处理，鼠标悬浮时提示已使用
2. 在设置中新增选项，用来控制是否开启激活码划线功能
3. 如果开启此功能，仅当帖子主题中包含'送码'/'激活码'/'注册码'/'key'/'code'/'兑换码'/'序列号'这些关键词时，该功能才生效
4. 通过sessionstorage缓存当前已从回复中获取的已使用的激活码，避免翻页后之前的划线失效问题。当前标签页关闭后缓存数据会清空。

效果如下图：
![code包裹和无包裹](https://github.com/user-attachments/assets/8946f3ee-3c17-47cb-8b43-bf6cbe5d4089)
![ul包裹](https://github.com/user-attachments/assets/256b6f93-c90b-4583-acc7-ca70b54885ed)
![table包裹](https://github.com/user-attachments/assets/4bef1979-c749-4f72-b9e6-4ab394d26e30)
![code包裹且注册码被分割](https://github.com/user-attachments/assets/247418a4-3f6b-4aa4-befb-e64ac9fce661)
